### PR TITLE
Add a note to the readme pointing to an alternative for people using monger

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Mongodb-session use mongodb as a Clojure/Ring's http session storage.
 
+**Alternative**: This library relies on [congomongo](https://github.com/congomongo/congomongo) as a MongoDB client. If you are using [monger](http://clojuremongodb.info/), consider using [mongers built-in session support](http://clojuremongodb.info/articles/integration.html#using_mongodbbacked_ring_session_store_with_monger).
+
 ## Usage
 ### Functional access
 **ring.middleware.session** version.<br>


### PR DESCRIPTION
This repo popped up on the top of my search results when I looked for a ring session implementation using MongoDB. Assuming that this project hasn't seen activity for a long time and most people are likely to use monger these days (congomongo itself is in a less maintained mode these days), this PR adds a note that will point people ending up here into the right direction.